### PR TITLE
Fix broken link to description of Tock syscalls

### DIFF
--- a/book/tutorials/04_sensors_and_drivers.html
+++ b/book/tutorials/04_sensors_and_drivers.html
@@ -185,7 +185,7 @@ int main() {
 </code></pre>
 </li>
 <li>
-<p><strong>Fill in the application with syscalls</strong>. The standard <a href="../Syscalls.html">Tock
+<p><strong>Fill in the application with syscalls</strong>. The standard <a href="https://github.com/tock/tock/blob/master/doc/Syscalls.md">Tock
 syscalls</a> can be used to actually implement the sketch we
 made above. We first use the <code>subscribe</code> syscall to inform the kernel about
 the callback in our application. We then use the <code>command</code> syscall to start


### PR DESCRIPTION
Fix broken link to description of Tock syscalls