### PR TITLE
HOTP Course Updates (Jan 2024)

### DIFF
--- a/src/SUMMARY.md
+++ b/src/SUMMARY.md
@@ -17,6 +17,7 @@ Tock OS Course
     - [HOTP Application](./key-hotp-application.md)
     - [Encryption Oracle Capsule](./key-hotp-oracle.md)
     - [Access Control](./key-hotp-access.md)
+    - [Security Key Demo](./key-hotp-demo.md)
   - [Kernel Boot](./boot.md)
   - [Policies](./policies.md)
   - [TicKV](./tickv.md)

--- a/src/SUMMARY.md
+++ b/src/SUMMARY.md
@@ -13,7 +13,7 @@ Tock OS Course
   - [USB Security Key](./key-overview.md)
     - [Kernel: USB Keyboard](./usb-hid.md)
     - [Kernel: HMAC](./key-hotp-hmac.md)
-    - [Kernel: App State](./key-hotp-appstate.md)
+    - [Kernel: Key-Value](./key-hotp-kv.md)
     - [HOTP Application](./key-hotp-application.md)
     - [Encryption Oracle Capsule](./key-hotp-oracle.md)
     - [Access Control](./key-hotp-access.md)

--- a/src/key-hotp-access.md
+++ b/src/key-hotp-access.md
@@ -1,9 +1,10 @@
 # Security Key Application Access Control
 
-With security-focused and privileged system resources, a board may wish to
-restrict which applications can access which system call resources. In this
-stage we will extend the Tock kernel to restrict access to the encryption
-capsule to only trusted (credentialed) apps.
+At this point we have a fully-featured HOTP USB security key implementation.
+However, the kernel APIs that enable this are exposed to any application running
+on the system. In this submodule, we will use additional features of the Tock
+kernel to restrict access to the encryption capsule to only trusted
+(credentialed) apps.
 
 ## Background
 
@@ -335,7 +336,6 @@ pub trait SyscallFilter {
         Ok(())
     }
 }
-
 ```
 
 We need to implement the single `filter_syscall()` function with out desired

--- a/src/key-hotp-demo.md
+++ b/src/key-hotp-demo.md
@@ -1,0 +1,3 @@
+# Using the HOTP USB Security Key
+
+With our fully functional USB security key, we can now put it to use.

--- a/src/key-hotp-hmac.md
+++ b/src/key-hotp-hmac.md
@@ -4,6 +4,34 @@ Our next task is we need an HMAC engine for our HOTP application to use. Tock
 already includes HMAC-SHA256 as a capsule within the kernel, we just need to
 expose it to userspace.
 
+## Background
+
+An HMAC engine is a necessary tool for a HOTP security key. From
+[Wikipedia](https://en.wikipedia.org/wiki/HMAC):
+
+> An HMAC...is a specific type of message authentication code (MAC) involving a
+> cryptographic hash function and a secret cryptographic key. As with any MAC,
+> it may be used to simultaneously verify both the data integrity and
+> authenticity of a message. An HMAC is a type of keyed hash function that can
+> also be used in a key derivation scheme or a key stretching scheme.
+
+An HMAC is computed roughly using the following equation (for simplicity this
+omits details on padding):
+
+```
+HMAC = Hash(Key + Hash(Key + Message))
+```
+
+The result is a output the length of the output of the hash function used.
+Because the key is used inside the hash operation, only someone who knows the
+secret key can compute the correct HMAC (authenticity). And because the message
+is used inside the hash operation, if the message is altered the HMAC will no
+longer match (integrity).
+
+HMAC supports any hash function, but the specific hash function used affects the
+resulting HMAC. Therefore we must specify. In this example, we will use the
+SHA256 hash algorithm. That means the resulting HMAC will be 32 bytes long.
+
 ## Configuring the Kernel
 
 First we need to use components to instantiate a software implementation of

--- a/src/key-hotp-kv.md
+++ b/src/key-hotp-kv.md
@@ -1,0 +1,185 @@
+# Using Key-Value Storage in Userspace
+
+When we use the HOTP application to store new keys, we want those keys to be
+persistent across reboots. That is, if we unplug the USB key, we would like our
+saved keys to still be accessible when we plug the key back in.
+
+To enable this, we are using Tock's Key-Value (KV) interface. This allows
+userspace applications to store data in the form of key-value pairs.
+Applications can retrieve data by querying for the given key.
+
+## Checking if Key-Value Support Already Exists
+
+Having key-value support is useful for more cases than just implementing an HOTP
+key, and so it is possible that your board already has key-value support
+enabled.
+
+To check this, load the `kv_check` test app onto your board:
+
+```
+cd libtock-c/examples/tests/kv_check
+make
+tockloader install
+```
+
+Run `tockloader listen` and reset the board. You should see the following output
+if KV support exists:
+
+```
+[KV] Check for Key-Value Support
+Key-Value support is enabled.
+```
+
+> If KV support already exists, you can skip this module!
+
+## Configuring the Kernel
+
+Again we will use components to add key-value support to the kernel.
+
+### 1. Include the Key-Value Stack Types
+
+The KV stack includes many layers which leads to rather complex types. For more
+information about the KV stack in Tock, see the [TicKV](tickv.md) reference. To
+simplify somewhat, we define a series of types used at each layer of the stack.
+Include these towards the top of main.rs:
+
+```rust
+// TicKV
+type Mx25r6435f = components::mx25r6435f::Mx25r6435fComponentType<
+    nrf52840::spi::SPIM<'static>,
+    nrf52840::gpio::GPIOPin<'static>,
+    nrf52840::rtc::Rtc<'static>,
+>;
+const TICKV_PAGE_SIZE: usize =
+    core::mem::size_of::<<Mx25r6435f as kernel::hil::flash::Flash>::Page>();
+type Siphasher24 = components::siphash::Siphasher24ComponentType;
+type TicKVDedicatedFlash =
+    components::tickv::TicKVDedicatedFlashComponentType<Mx25r6435f, Siphasher24, TICKV_PAGE_SIZE>;
+type TicKVKVStore = components::kv::TicKVKVStoreComponentType<
+    TicKVDedicatedFlash,
+    capsules_extra::tickv::TicKVKeyType,
+>;
+type KVStorePermissions = components::kv::KVStorePermissionsComponentType<TicKVKVStore>;
+type VirtualKVPermissions = components::kv::VirtualKVPermissionsComponentType<KVStorePermissions>;
+type KVDriver = components::kv::KVDriverComponentType<VirtualKVPermissions>;
+```
+
+Note the first type is the underlying flash driver where the KV database is
+actually stored. This will need to be customized for your specific board and
+flash device.
+
+### 2. Include the KV Components
+
+Now we can use those types to instantiate the components for each layer of the
+KV stack:
+
+```rust
+//--------------------------------------------------------------------------
+// TICKV
+//--------------------------------------------------------------------------
+
+// Static buffer to use when reading/writing flash for TicKV.
+let page_buffer = static_init!(
+    <Mx25r6435f as kernel::hil::flash::Flash>::Page,
+    <Mx25r6435f as kernel::hil::flash::Flash>::Page::default()
+);
+
+// SipHash for creating TicKV hashed keys.
+let sip_hash = components::siphash::Siphasher24Component::new()
+    .finalize(components::siphasher24_component_static!());
+
+// TicKV with Tock wrapper/interface.
+let tickv = components::tickv::TicKVDedicatedFlashComponent::new(
+    sip_hash,
+    mx25r6435f,
+    0, // start at the beginning of the flash chip
+    (capsules_extra::mx25r6435f::SECTOR_SIZE as usize) * 32, // arbitrary size of 32 pages
+    page_buffer,
+)
+.finalize(components::tickv_dedicated_flash_component_static!(
+    Mx25r6435f,
+    Siphasher24,
+    TICKV_PAGE_SIZE,
+));
+
+// KVSystem interface to KV (built on TicKV).
+let tickv_kv_store = components::kv::TicKVKVStoreComponent::new(tickv).finalize(
+    components::tickv_kv_store_component_static!(
+        TicKVDedicatedFlash,
+        capsules_extra::tickv::TicKVKeyType,
+    ),
+);
+
+let kv_store_permissions = components::kv::KVStorePermissionsComponent::new(tickv_kv_store)
+    .finalize(components::kv_store_permissions_component_static!(
+        TicKVKVStore
+    ));
+
+// Share the KV stack with a mux.
+let mux_kv = components::kv::KVPermissionsMuxComponent::new(kv_store_permissions).finalize(
+    components::kv_permissions_mux_component_static!(KVStorePermissions),
+);
+
+// Create a virtual component for the userspace driver.
+let virtual_kv_driver = components::kv::VirtualKVPermissionsComponent::new(mux_kv).finalize(
+    components::virtual_kv_permissions_component_static!(KVStorePermissions),
+);
+
+// Userspace driver for KV.
+let kv_driver = components::kv::KVDriverComponent::new(
+    virtual_kv_driver,
+    board_kernel,
+    capsules_extra::kv_driver::DRIVER_NUM,
+)
+.finalize(components::kv_driver_component_static!(
+    VirtualKVPermissions
+));
+```
+
+This example is for the nRF52840dk board. You will likely need to change the
+`mx25r6435f` flash driver to the flash driver appropriate for your board.
+
+### 3. Update the `Platform` Struct and Expose KV to Userspace
+
+We need to include the `kv_driver` in the board's platform struct:
+
+Then add these capsules to the `Platform` struct:
+
+```rust
+pub struct Platform {
+    ...
+    kv_driver: &'static KVDriver,
+    ...
+}
+
+let platform = Platform {
+    ...
+    kv_driver,
+    ...
+};
+```
+
+And make the syscall interface available to userspace:
+
+```rust
+impl SyscallDriverLookup for Platform {
+    fn with_driver<F, R>(&self, driver_num: usize, f: F) -> R
+    where
+        F: FnOnce(Option<&dyn kernel::syscall::SyscallDriver>) -> R,
+    {
+        match driver_num {
+            ...
+            capsules_extra::kv_driver::DRIVER_NUM => f(Some(self.kv_driver)),
+            ...
+        }
+    }
+}
+```
+
+> **Checkpoint:** Key-Value is now accessible to userspace!
+
+## Testing and Trying Out KV Storage
+
+With KV support in your Tock kernel, you can use the applications in
+`libtock-c/examples/tests/kv*` to experiment with KV storage. In particular, the
+`kv_interactive` app allows you to get and set key-value pairs.

--- a/src/key-hotp-oracle.md
+++ b/src/key-hotp-oracle.md
@@ -2,12 +2,13 @@
 
 Our HOTP security key works by storing a number of secrets on the device, and
 using these secrets together with some _moving factor_ (e.g., a counter value or
-the current time) in an HMAC operation. This implies that our device needs some
-way to store these secrets, for instance in its internal flash.
+the current time) in an HMAC operation. To be useful, our device needs some way
+to store these secrets, for instance in its internal flash.
 
-However, storing such secrets in plaintext in ordinary flash is not particularly
-secure. For instance, many microcontrollers offer debug ports which can be used
-to gain read and write access to flash. Even if these ports can be locked down,
+However, storing such secrets in plaintext as we did in the previous submodule
+is not particularly secure. For instance, many microcontrollers offer debug
+ports which can be used to gain read and write access to flash. Even if these
+ports can be locked down,
 [such protection mechanisms have been broken in the past](https://blog.includesecurity.com/2015/11/firmware-dumping-technique-for-an-arm-cortex-m0-soc/).
 Apart from that, disallowing external flash access makes debugging and updating
 our device much more difficult.
@@ -32,7 +33,9 @@ some important concepts in Tock:
 - Tock's hardware-interface layers (HILs), which provide abstract interfaces for
   hardware or software implementations of algorithms, devices and protocols.
 
-## Capsules – Tock's Kernel Modules
+## Background
+
+### Capsules – Tock's Kernel Modules
 
 Most of Tock's functionality is implemented in the form of capsules – Tock's
 equivalent to kernel modules. Capsules are Rust modules contained in Rust crates
@@ -47,6 +50,19 @@ _correctness_ – meaning that they must not block the kernel execution for long
 periods of time, and should behave correctly according to their specifications
 and API contracts.
 
+### Capsule Directory in the Tock Repository
+
+While a single "capsule" is generally self-contained in a Rust _module_ (`.rs`
+file), these modules are again grouped into Rust crates such as `capsules/core`
+and `capsules/extra`, depending on certain policies. For instance, capsules in
+`core` have stricter requirements regarding their code quality and API
+stability. Neither `core` nor the `extra` `extra` capsules crates allow for
+external dependencies (outside of the Tock repository).
+[The document on external dependencies](https://github.com/tock/tock/blob/master/doc/ExternalDependencies.md)
+further explains these policies.
+
+## Developing the Encryption Oracle
+
 We start our encryption oracle driver by creating a new capsule called
 `encryption_oracle`. Create a file under
 `capsules/extra/src/tutorials/encryption_oracle.rs` in the Tock kernel
@@ -55,7 +71,7 @@ repository with the following contents:
 ```rust
 // Licensed under the Apache License, Version 2.0 or the MIT License.
 // SPDX-License-Identifier: Apache-2.0 OR MIT
-// Copyright Tock Contributors 2022.
+// Copyright Tock Contributors 2024.
 
 pub static KEY: &'static [u8; kernel::hil::symmetric_encryption::AES128_KEY_SIZE] =
     b"InsecureAESKey12";
@@ -71,8 +87,9 @@ impl EncryptionOracleDriver {
 
 ```
 
-We will be filling this module with more interesting contents soon. To make this
-capsule accessible to other Rust modules and crates, add it to
+This is the basic skeleton for a Tock capsule.
+
+To make this capsule accessible to other Rust modules and crates, add it to
 `capsules/extra/src/tutorials/mod.rs`:
 
 ```diff
@@ -92,16 +109,7 @@ checkpoints through blocks such as the following:
 
 > **CHECKPOINT:** `encryption_oracle_chkpt0.rs`
 
-> **BACKGROUND:** While a single "capsule" is generally self-contained in a Rust
-> _module_ (`.rs` file), these modules are again grouped into Rust crates such
-> as `capsules/core` and `capsules/extra`, depending on certain policies. For
-> instance, capsules in `core` have stricter requirements regarding their code
-> quality and API stability. Neither `core` nor the `extra` `extra` capsules
-> crates allow for external dependencies (outside of the Tock repository).
-> [The document on external dependencies](https://github.com/tock/tock/blob/master/doc/ExternalDependencies.md)
-> further explains these policies.
-
-## Userspace Drivers
+### Userspace Drivers
 
 Now that we have a basic capsule skeleton, we can think about how this code is
 going to interact with userspace applications. Not every capsule needs to offer
@@ -111,63 +119,41 @@ a userspace API, but those that do must implement
 Tock supports different types of application-issued systems calls, four of which
 are relevant to userspace drivers:
 
-- _subscribe_: An application can issue a _subscribe_ system call to register
-  _upcalls_, which are functions being invoked in response to certain events.
-  These upcalls are similar in concept to UNIX signal handlers. A driver can
-  request an application-provided upcall to be invoked. Every system call driver
-  can provide multiple "subscribe slots", each of which the application can
-  register a upcall to.
+- _subscribe_: Allows an application to register _upcalls_, which are functions
+  being invoked in response to certain events.
 
-- _read-only allow_: An application may expose some data for drivers to read.
-  Tock provides the _read-only allow_ system call for this purpose: an
-  application invokes this system call passing a buffer, the contents of which
-  are then made accessible to the requested driver. Every driver can have
-  multiple "allow slots", each of which the application can place a buffer in.
+- _read-only allow_: Allows an application to share a buffer with a kernel
+  module. The kernel only has read access to the buffer.
 
-- _read-write allow_: Works similarly to read-only allow, but enables drivers to
-  also mutate the application-provided buffer.
+- _read-write allow_: Same as the read-only allow, but kernel modules can also
+  mutate the application-provided buffer.
 
-- _command_: Applications can use _command_-type system calls to signal
-  arbitrary events or send requests to the userspace driver. A common use-case
-  for command-style systems calls is, for instance, to request that a driver
-  start some long-running operation.
+- _command_: Allows applications to signal arbitrary events or send requests to
+  the kernel module.
 
 All Tock system calls are synchronous, which means that they should immediately
-return to the application. In fact, _subscribe_ and _allow_-type system calls
-are transparently handled by the kernel, as we will see below. Capsules must not
-implement long-running operations by blocking on a command system call, as this
-prevents other applications or kernel routines from running – kernel code is
-never preempted.
+return to the application. Capsules must not implement long-running operations
+by blocking on a command system call.
 
-## Application Grants
+More information can be found in the
+[syscalls documentation](https://github.com/tock/tock/blob/master/doc/Syscalls.md#overview-of-system-calls-in-tock).
+
+### Application Grants
 
 Now there's just one key part missing to understanding Tock's system calls: how
-drivers store application-specific data. Tock differs significantly from other
-operating systems in this regard, which typically simply allocate some memory on
-demand through a _heap allocator_.
+kernel modules store application-specific data. To avoid using a standard heap,
+which could be exhausted and leave the kernel in an unrecoverable state, Tock
+uses _grants_. Grants are essentially regions of the application's allocated
+memory space that the kernel uses to store state on behalf of the process. This
+is distinct from an allow as the application never has access to grant data.
+More information can be found in the
+[grants documentation](https://github.com/tock/tock/blob/master/doc/Design.md#grants).
 
-However, on resource constraint platforms such as microcontrollers, allocating
-from a pool of (limited) memory can inevitably become a prominent source of
-resource exhaustion errors: once there's no more memory available, Tock wouldn't
-be able to service new allocation requests, without revoking some prior
-allocations. This is especially bad when this memory pool is shared between
-kernel resources belonging to multiple processes, as then one process could
-potentially starve another.
-
-To avoid these issues, Tock uses _grants_. A grant is a memory allocation
-belonging to a process, and is located within a process-assigned memory
-allocation, but reserved for use by the kernel. Whenever a kernel component must
-keep track of some process-related information, it can use a grant to hold this
-information. By allocating memory from a process-specific memory region it is
-impossible for one process to starve another's memory allocations, independent
-of whether those allocations are in the process itself or in the kernel. As a
-consequence, Tock can avoid implementing a kernel heap allocator entirely.
-
-Ultimately, our encryption oracle driver will need to keep track of some
-per-process state. Thus we extend the above driver with a Rust struct to be
-stored within a grant, called `App`. For now, we just keep track of whether a
-process has requested a decryption operation. Add the following code snippet to
-your capsule:
+Our encryption oracle driver will need to keep track of some per-process state.
+Thus we extend the above driver with a Rust struct to be stored within a grant,
+called `ProcessState`. For now, we just keep track of whether a process has
+requested a decryption operation. Add the following code snippet to your
+capsule:
 
 ```rust
 #[derive(Default)]
@@ -206,11 +192,11 @@ pub struct EncryptionOracleDriver {
 > argument. Afterwards, make sure your code compiles by running `cargo check` in
 > the `capsules/extra/` directory.
 
-## Implementing a System Call
+### Implementing a System Call
 
-Now that we know about grants we can start to implement a proper system call. We
-start with the basics and implement a simple _command_-type system call: upon
-request by the application, the Tock kernel will call a method in our capsule.
+Next we can start to implement a proper system call. We start with the basics
+and implement a simple _command_-type system call: upon request by the
+application, the Tock kernel will call a method in our capsule.
 
 For this, we implement the following `SyscallDriver` trait for our
 `EncryptionOracleDriver` struct. This trait contains two important methods:
@@ -314,45 +300,17 @@ sufficient memory available), we handle any errors by converting them into a
 
 > **CHECKPOINT:** `encryption_oracle_chkpt1.rs`
 
-Congratulations, you have implemented your first Tock system call! Next, we will
-look into how to to integrate this driver into a kernel build.
+Congratulations, you have implemented your first Tock system call! Next we will
+add a resource to the kernel module.
 
-## Adding a Capsule to a Tock Kernel
+### Including an AES Engine in the Driver
 
-To actually make our driver available in a given build of the kernel, we need to
-add it to a _board crate_. Board crates tie the kernel, a given _chip_, and a
-set of drivers together to create a binary build of the Tock operating system,
-which can then be loaded into a physical board. For the purposes of this
-section, we assume to be targeting the Nordic Semiconductor nRF52840DK board,
-and thus will be working in the `boards/nordic/nrf52840dk/` directory.
+Our encryption oracle will encrypt the HOTP keys before we store them to flash.
+Therefore it needs access to an encryption engine. We will use AES.
 
-> **EXERCISE:** Enter the `boards/nordic/nrf52840dk/` directory and compile a
-> kernel by typing `make`. A successful build should end with a message that
-> looks like the following:
->
->         Finished release [optimized + debuginfo] target(s) in 20.34s
->        text    data     bss     dec     hex filename
->      176132       4   33284  209420   3320c /home/tock/tock/target/thumbv7em-none-eabi/release/nrf52840dk
->     [Hash ommitted]  /home/tock/tock/target/thumbv7em-none-eabi/release/nrf52840dk.bin
-
-Applications interact with our driver by passing a "driver number" alongside
-their system calls. The `capsules/core/src/driver.rs` module acts as a registry
-for driver numbers. For the purposes of this tutorial we'll use an unassigned
-driver number in the _misc_ range, `0x99999`, and add a constant to capsule
-accordingly:
-
-```rust
-pub const DRIVER_NUM: usize = 0x99999;
-```
-
-### Accepting an AES Engine in the Driver
-
-Before we start adding our driver to the board crate, we'll modify it slightly
-to acceppt an instance of an `AES128` cryptography engine. This is to avoid
-modifying our driver's instantiation later on. We provide the
-`encryption_oracle_chkpt2.rs` checkpoint which has these changes integrated,
-feel free to use this code. We make the following mechanical changes to our
-types and constructor – don't worry about them too much right now.
+We provide the `encryption_oracle_chkpt2.rs` checkpoint which has these changes
+integrated, feel free to use this code. We make the following mechanical changes
+to our types and constructor – don't worry about them too much right now.
 
 First, we change our `EncryptionOracleDriver` struct to hold a reference to some
 generic type `A`, which must implement the `AES128` and the `AESCtr` traits:
@@ -398,16 +356,35 @@ types:
           &self,
 ```
 
-Finally, make sure that your modified capsule still compiles.
+Make sure that your modified capsule still compiles. We will actual use the AES
+engine later. Next, we will look into how to to integrate this driver into a
+kernel build.
 
 > **CHECKPOINT:** `encryption_oracle_chkpt2.rs`
 
+### Adding a Capsule to a Tock Kernel
+
+To actually make our driver available in a given build of the kernel, we need to
+assign it a number and add it to our board's main.rs.
+
+#### Specifying the Driver Number
+
+Applications interact with our driver by passing a "driver number" alongside
+their system calls. The `capsules/core/src/driver.rs` module acts as a registry
+for driver numbers. For the purposes of this tutorial we'll use an unassigned
+driver number in the _misc_ range, `0x99999`, and add a constant to capsule
+accordingly:
+
+```rust
+pub const DRIVER_NUM: usize = 0x99999;
+```
+
 ### Instantiating the System Call Driver
 
-Now, open the board's main file (`boards/nordic/nrf52840dk/src/main.rs`) and
-scroll down to the line that reads "_PLATFORM SETUP, SCHEDULER, AND START KERNEL
-LOOP_". We'll instantiate our encryption oracle driver right above that, with
-the following snippet:
+Now, open the board's main file (for example
+`boards/nordic/nrf52840dk/src/main.rs`) and scroll down to the line that reads
+"_PLATFORM SETUP, SCHEDULER, AND START KERNEL LOOP_". We'll instantiate our
+encryption oracle driver right above that, with the following snippet:
 
 ```rust
 const CRYPT_SIZE: usize = 7 * kernel::hil::symmetric_encryption::AES128_BLOCK_SIZE;
@@ -435,6 +412,10 @@ let oracle = static_init!(
 // Leave commented out for now:
 // kernel::hil::symmetric_encryption::AES128::set_client(&base_peripherals.ecb, oracle);
 ```
+
+If you are using a microcontroller other than the nRF52840, you will need to
+modify the types slightly and provide the correct reference to the AES hardware
+engine.
 
 Now that we instantiated our capsule, we need to wire it up to Tock's system
 call handling facilities. This involves two steps: first, we need to store our
@@ -504,29 +485,25 @@ build.
 > Upon receiving this system call, the capsule should print the "Received
 > request from process" message.
 
-## Interacting with HILs
+### Interacting with HILs
 
-The Tock operating system supports different hardware platforms, each featuring
-an individual set of integrated peripherals. At the same time, a driver such as
-our encryption oracle should be portable between different systems running Tock.
-To achieve this, Tock uses the concept of Hardware-Interface Layers (HILs), the
-design paradigms of which are described in
-[this document](https://github.com/tock/tock/blob/master/doc/reference/trd3-hil-design.md).
-HILs are organized as Rust modules, and can be found under the
+The Tock operating system supports multiple hardware platforms, each with
+different implementations and hardware peripherals. To provide consistent
+intefaces to kernel modules, Tock uses Hardware-Interface Layers (HILs). HILs
+are can be found under the
 [`kernel/src/hil/`](https://github.com/tock/tock/tree/master/kernel/src/hil)
 directory. We will be working with the
 [`symmetric_encryption.rs` HIL](https://github.com/tock/tock/blob/master/kernel/src/hil/symmetric_encryption.rs).
+You can read more about the design paradigms of HILs in
+[this document](https://github.com/tock/tock/blob/master/doc/reference/trd3-hil-design.md).
 
 HILs capture another important concept of the Tock kernel: asynchronous
-operations. As mentioned above, Tock system calls must never block for extended
-periods of time, as kernel code is not preempted. Blocking in the kernel
-prevents other useful being done. Instead, long-running operations in the Tock
-kernel are implemented as asynchronous _two-phase_ operations: one function call
-on the underlying implementation (e.g., of our AES engine) starts an operation,
-and another function call (issued by the underlying implementation, hence named
-_callback_) informs the driver that the operation has completed. You can see
-this paradigm embedded in all of Tock's HILs, including the
-`symmetric_encryption` HIL: the
+operations. Operations in the Tock kernel are implemented as asynchronous
+_two-phase_ operations: one function call on the underlying implementation
+(e.g., of our AES engine) starts an operation, and another function call (issued
+by the underlying implementation) informs the driver that the operation has
+completed. You can see this paradigm embedded in all of Tock's HILs, including
+the `symmetric_encryption` HIL: the
 [`crypt()` method](https://github.com/tock/tock/blob/75af40ea947dfab3c1db57a04ca6273fde895a3a/kernel/src/hil/symmetric_encryption.rs#L84)
 is specified to return immediately (and return a `Some(_)` in case of an error).
 When the requested operation is finished, the implementor of `AES128` will call
@@ -535,13 +512,13 @@ the
 on the _client_ registered with
 [`set_client()`](https://github.com/tock/tock/blob/75af40ea947dfab3c1db57a04ca6273fde895a3a/kernel/src/hil/symmetric_encryption.rs#L31).
 
-The below figure illustates the way asynchronous operations are handled in Tock,
-using our encryption oracle capsule as an example. One further detail
+The below figure illustrates the way asynchronous operations are handled in
+Tock, using our encryption oracle capsule as an example. One further detail
 illustrated in this figure is the fact that providers of a given interface
 (e.g., `AES128`) may not always be able to perform a large user-space operation
 in a single call; this may be because of hardware-limitations, limited buffer
 allocations, or to avoid blocking the kernel for too long in
-software-implentations. In this case, a userspace-operation is broken up into
+software-implementations. In this case, a userspace-operation is broken up into
 multiple smaller operations on the underlying provider, and the next
 sub-operation is scheduled once a callback has been received:
 
@@ -562,7 +539,7 @@ impl<'a, A: AES128<'a> + AES128Ctr> Client<'a> for EncryptionOracleDriver<'a, A>
 
 With this trait implemented, we can wire up the `oracle` driver instance to
 receive callbacks from the AES engine (`base_peripherals.ecb`) by uncommenting
-the following line in `boards/nordic/nrf52840dk/src/main.rs`:
+the following line in `main.rs`:
 
 ```diff
 - // Leave commented out for now:
@@ -575,16 +552,15 @@ AES hardware that an operation has finished, and it will thus refuse to start
 any new operation. This is an easy mistake to make – you should check whether
 all callbacks are set up correctly when the kernel is in such a _stuck_ state.
 
-### Multiplexing Between Processes
+#### Multiplexing Between Processes
 
 While our underlying `AES128` implementation can only handle one request at a
 time, multiple processes may wish to use this driver. Thus our capsule
-implements a queueing system: even when another process is already using our
-capsule to decrypt some ciphertext, another process can still initate such a
-request. We remember these requests through the `request_pending` flag in our
-`ProcessState` grant, and we've already implemented the logic to set this flag!
+implements a queueing system: if our capsule is busy, another process can still
+mark a request which will set the `request_pending` flag in our `ProcessState`
+grant. Even better, we've already implemented the logic to set this flag!
 
-Now, to actually implement our asynchronous decryption operation, it is further
+Now, to actually implement our asynchronous decryption operation, it is
 important to keep track of which process' request we are currently working on.
 We add an additional state field to our `EncryptionOracleDriver` holding an
 [`OptionalCell`](https://docs.tockos.org/kernel/utilities/cells/struct.optionalcell):
@@ -636,13 +612,13 @@ fn next_pending(&self) -> Option<ProcessId> {
 > Hint: to interact with the `ProcessState` of every processes, you can use the
 > [`iter` method on a `Grant`](https://docs.tockos.org/kernel/grant/struct.grant#method.iter):
 > the returned `Iter` type then has an `enter` method access the contents of an
-> invidiual process' grant.
+> individual process' grant.
 
 > **CHECKPOINT:** `encryption_oracle_chkpt3.rs`
 
-### Interacting with Process Buffers and Scheduling Upcalls
+#### Interacting with Process Buffers and Scheduling Upcalls
 
-For our encryption oracle, it is important to allow users provide buffers
+For our encryption oracle, it is important to allow users to provide buffers
 containing the encryption _initialization vector_ (to prevent an attacker from
 inferring relationships between messages encrypted with the same key), and the
 plaintext or ciphertext to encrypt and decrypt respectively. Furthermore,

--- a/src/key-overview.md
+++ b/src/key-overview.md
@@ -78,7 +78,7 @@ This module is broken into four stages:
 1. Configuring the kernel to provide necessary syscall drivers:
    1. [USB Keyboard Device](./usb-hid.md).
    2. [HMAC](./key-hotp-hmac.md)
-   3. [App State](./key-hotp-appstate.md)
+   3. [Key-Value](./key-hotp-kv.md)
 2. [Creating an HOTP userspace application](./key-hotp-application.md).
 3. [Creating an in-kernel encryption oracle](./key-hotp-oracle.md).
 4. [Enforcing access control restrictions to the oracle](./key-hotp-access.md).

--- a/src/key-overview.md
+++ b/src/key-overview.md
@@ -47,6 +47,30 @@ For now, you should plug one USB cable into the top of the board for programming
 (NOT into the "nRF USB" port on the side). We'll attach the other USB cable
 later.
 
+## Organization and Getting Oriented to Tock
+
+This module will refer to various Tock components. This section briefly
+describes the general structure of Tock you will need to be somewhat familiar
+with to follow the module.
+
+Using Tock consists of two main building blocks:
+
+1. The Tock kernel, which runs as the operating system on the board. This is
+   compiled from the [Tock repository](https://github.com/tock/tock).
+2. Userspace applications, which run as processes and are compiled and loaded
+   separately from the kernel.
+
+The Tock kernel is compiled specifically for a particular hardware device,
+termed a "board". The location of the top-level file for the kernel on a
+specific board is in the Tock repository, under `/tock/boards/<board name>`. Any
+time you need to compile the kernel or edit the board file, you will go to that
+folder. You also install the kernel on the hardware board from that directory.
+
+Userspace applications are stored in a separate repository, either
+[libtock-c](https://github.com/tock/libtock-c) or
+[libtock-rs](https://github.com/tock/libtock-rs) (for C and Rust applications,
+respectively). Those applications are compiled within those repositories.
+
 ## Stages
 
 This module is broken into four stages:

--- a/src/usb-hid.md
+++ b/src/usb-hid.md
@@ -4,6 +4,25 @@ The Tock kernel supports implementing a USB device and we can setup our kernel
 so that it is recognized as a USB keyboard device. This is necessary to enable
 the HOTP key to send the generated key to the computer when logging in.
 
+## Background
+
+This module configures your hardware board to be a USB HID device. From
+[Wikipedia](https://en.wikipedia.org/wiki/USB_human_interface_device_class):
+
+> The USB human interface device class (USB HID class) is a part of the USB
+> specification for computer peripherals: it specifies a device class (a type of
+> computer hardware) for human interface devices such as keyboards, mice, game
+> controllers and alphanumeric display devices.
+>
+> The USB HID class describes devices used with nearly every modern computer.
+> Many predefined functions exist in the USB HID class. These functions allow
+> hardware manufacturers to design a product to USB HID class specifications and
+> expect it to work with any software that also meets these specifications.
+
+Enabling USB HID will allow your board to operate as a normal keyboard. As far
+as your computer is concerned, you plugged in a USB keyboard. This means your
+board and microcontroller can "type" to your computer.
+
 ## Configuring the Kernel
 
 We need to setup our kernel to include USB support, and particularly the USB HID


### PR DESCRIPTION
This includes a refresh of the hotp tutorial docs.

- Switch app state to KV
- Simplify setting up kernel resources using component types
- Condense oracle doc a bit
- General formatting and wording update, trying to make the different submodules more cohesive