### PR TITLE
Add a chapter listing to the dev guides first page

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -109,15 +109,7 @@ check_mdbook_pagetoc:
 # mdbook-chapter-list doesn't support the version flag
 CHAPTERLIST_FILENAME := mdbook-chapter-list-v$(MDBOOK_CHAPTERLIST_VERSION)-x86_64-unknown-linux-gnu.tar.gz
 install_mdbook_chapterlist:
-ifndef CI
 	cargo install mdbook-chapter-list --version $(MDBOOK_CHAPTERLIST_VERSION)
-else
-	rm -f $(CHAPTERLIST_FILENAME)
-	curl -L https://github.com/bradjc/mdbook-chapter-list/releases/download/v$(MDBOOK_CHAPTERLIST_VERSION)/$(CHAPTERLIST_FILENAME) -O
-	tar -xzf $(CHAPTERLIST_FILENAME)
-	chmod +x mdbook-chapter-list
-	rm $(CHAPTERLIST_FILENAME)
-endif
 
 # mdbook-chapter-list doesn't support the version flag
 check_mdbook_chapterlist:

--- a/Makefile
+++ b/Makefile
@@ -15,6 +15,7 @@ SHELL = /usr/bin/env bash
 MDBOOK_VERSION := 0.4.32
 MDBOOK_LINKCHECK_VERSION := 0.7.7
 MDBOOK_PAGETOC_VERSION := 0.1.7
+MDBOOK_CHAPTERLIST_VERSION := 0.1.0
 PRETTIER_VERSION := 3.0.0
 
 # For CI, use local install; for normal users system install
@@ -24,6 +25,7 @@ Q := @
 MDBOOK := mdbook
 MDBOOK_LINKCHECK := mdbook-linkcheck
 MDBOOK_PAGETOC := mdbook-pagetoc
+MDBOOK_CHAPTERLIST := mdbook-chapter-list
 PRETTIER := prettier
 else
 $(info *** Running in CI environment ***)
@@ -31,6 +33,7 @@ Q :=
 MDBOOK := mdbook
 MDBOOK_LINKCHECK := mdbook-linkcheck
 MDBOOK_PAGETOC := mdbook-pagetoc
+MDBOOK_CHAPTERLIST := mdbook-chapter-list
 PRETTIER := prettier
 export TERM := dumb
 # Allow local installs
@@ -38,7 +41,7 @@ export PATH := $(PATH):$(CURDIR)
 endif
 
 # The only thing we really want to do is build
-all:	check_mdbook check_mdbook_linkcheck check_mdbook_pagetoc check_prettier
+all:	check_mdbook check_mdbook_linkcheck check_mdbook_pagetoc check_mdbook_chapterlist check_prettier
 	@echo $$(tput bold)All required tools installed with correct version.$$(tput sgr0)
 	$(Q)$(PRETTIER) --check --prose-wrap always '**/*.md' || (echo $$(tput bold)$$(tput setaf 1)Source formatting errors.; echo Run \"make pretty\" to fix automatically.; echo Warning: will overwrite files in-place.$$(tput sgr0); exit 1)
 	@echo $$(tput bold)Source file formatting correct.$$(tput sgr0)
@@ -101,6 +104,24 @@ check_mdbook_pagetoc:
 	$(Q)$(MDBOOK_PAGETOC) --help > /dev/null || $(MAKE) install_mdbook_pagetoc
 	@#$(Q)[[ $$($(MDBOOK_PAGETOC) --version | cut -d' ' -f2) == '$(MDBOOK_PAGETOC_VERSION)' ]] || $(MAKE) install_mdbook_pagetoc
 	@#$(Q)$(MDBOOK_PAGETOC) --version || $(MAKE) install_mdbook_pagetoc
+
+
+# mdbook-chapter-list doesn't support the version flag
+CHAPTERLIST_FILENAME := mdbook-chapter-list-v$(MDBOOK_CHAPTERLIST_VERSION)-x86_64-unknown-linux-gnu.tar.gz
+install_mdbook_chapterlist:
+ifndef CI
+	cargo install mdbook-chapter-list --version $(MDBOOK_CHAPTERLIST_VERSION)
+else
+	rm -f $(CHAPTERLIST_FILENAME)
+	curl -L https://github.com/bradjc/mdbook-chapter-list/releases/download/v$(MDBOOK_CHAPTERLIST_VERSION)/$(CHAPTERLIST_FILENAME) -O
+	tar -xzf $(CHAPTERLIST_FILENAME)
+	chmod +x mdbook-chapter-list
+	rm $(CHAPTERLIST_FILENAME)
+endif
+
+# mdbook-chapter-list doesn't support the version flag
+check_mdbook_chapterlist:
+	$(Q)$(MDBOOK_CHAPTERLIST) --help > /dev/null || $(MAKE) install_mdbook_chapterlist
 
 
 

--- a/book.toml
+++ b/book.toml
@@ -9,5 +9,7 @@ title = "The Tock Book"
 additional-css = ["theme/pagetoc.css", "theme/pagetoc-tock.css"]
 additional-js  = ["theme/pagetoc.js"]
 
+[preprocessor.chapter-list]
+
 [output.linkcheck]
 optional = true

--- a/src/development/guides.md
+++ b/src/development/guides.md
@@ -11,3 +11,7 @@ code examples will fail to compile. However, the general design aspects and
 considerations should still be relevant even if the specific code details have
 changed. You are encourage to use these guides as just that, a general guide,
 and to copy from up-to-date examples contained in the Tock repository.
+
+## List of Guides:
+
+<!-- chapter-list -->


### PR DESCRIPTION
<img width="807" alt="image" src="https://github.com/tock/book/assets/1467890/4dcd27d3-bec6-45b4-afd4-00a7f8da2b0e">

Uses a new plugin so we can add `<!-- chapter-list -->` wherever we want a listing without writing it manually.