### PR TITLE
WSL Setup Steps

### DIFF
--- a/src/doc/syscalls.md
+++ b/src/doc/syscalls.md
@@ -185,7 +185,7 @@ three ways.
 ## System Call Implementations
 
 All system calls are implemented via context switches. A couple values are
-passed along with the context switch to indicate the type and manor of the
+passed along with the context switch to indicate the type and manner of the
 syscall. A process invokes a system call by triggering context switch via a
 software interrupt that transitions the microcontroller to supervisor/kernel
 mode. The exact mechanism for this is architecture-specific. [TRD104][TRD104]

--- a/src/getting_started.md
+++ b/src/getting_started.md
@@ -244,8 +244,8 @@ Steps to connect to nRF52840DK with WSL:
    `usbipd attach --wsl -b <busid>` on powershell/cmd (When attaching a device
    for the first time, it has to be done with admin previliges).
 
-10. To check if the attach worked, run `lsusb` on WSL. If the whole process
-    worked, the device should be listed and JLink should be able to find it.
+10. To check if the attach worked, run `lsusb` on WSL. If it worked, the device
+    should be listed as `SEGGER JLink`.
 
 11. The kernel can now be flashed with `make install` and other tockloader
     commands should work.
@@ -255,7 +255,6 @@ Steps to connect to nRF52840DK with WSL:
 > - Make sure your firewall is not blocking port 3240 as USBIP uses that port to
 >   interface windows and WSL. (Windows defender is usually the culprit if you
 >   don't have a third party firewall).
-
 > - Add an inbound rule to Windows defender/ your third party firewall allowing
 >   USBIP to use port 3240 if you see a port blocked error.
 

--- a/src/getting_started.md
+++ b/src/getting_started.md
@@ -195,6 +195,69 @@ The board should appear as a regular serial device (e.g.
 `/dev/tty.usbserial-c098e5130006` on my Mac or `/dev/ttyUSB0` on my Linux box).
 This may require some setup, see the "one-time fixups" box.
 
+
+### On Windows Subsystem for Linux (WSL)
+
+Programming JLink devices with Tock in WSL:
+
+Trying to program an nRF52840DK with WSL can be a little tricky because WSL2 
+abstracts away low level access for USB devices. WSL1 is unable to find JLink 
+devices even if you have JLink installed because of the USB abstraction. 
+To get around this, we use USBIP - a tool that connects the USB device over a 
+TCP tunnel. This guide might apply for any device programmed via JLink. 
+
+Steps to connect to nRF52840DK with WSL:
+
+1. Get Ubuntu 22.04 from microsoft store. Install it as a WSL distro with 
+`wsl --install -d Ubuntu-22.04` using Windows Powershell or Cmd prompt with 
+admin previliges. 
+
+2. Once Ubuntu 22.04 is installed, the Ubuntu 20.04 distro that ships as 
+default with WSL must be uninstalled. Set the 22.04 distro as the WSL 
+default by with the `wsl --setdefault Ubuntu-22.04` command. 
+
+3. Install JLink's linux package from their website on your WSL linux distro. 
+You may need to modify jlink rules to allow JLink to access the nRF52840DK. 
+This can be done with `sudo nano /etc/udev/rules.d/99-jlink.rules` and 
+adding `SUBSYSTEM=="tty", ATTRS{idVendor}=="1051", MODE="0666", GROUP="dialout"` 
+to the file.
+
+4. Next, the udev rules have to be reloaded and triggered with 
+`sudo udevadm control --reload-rules && udevadm trigger`. Doing this should 
+apply the new rules.
+
+5. On the windows platform, make sure WSL is set to version 2. Check the WSL 
+version with `wsl -l -v`. If it is version 1, change it to WSL2 with 
+`wsl --set-version Ubuntu-22.04 2`. 
+
+6. Install USBIP from [here](https://github.com/dorssel/usbipd-win/releases/tag/v4.1.0). 
+Version 4.x onwards removes USBIP tooling requirement from the client side, so you don't 
+have to install anything on the linux subsystem. 
+
+7. On windows, open powershell/cmd in admin mode and run `usbipd wsl list`. That should 
+give you the list of devices. Note the Bus ID of your J-Link device.
+
+8. For the first time that you want to attach your device, you need to bind the bus between 
+the host OS and the WSL using `usbipd bind -b <bus-id>`.
+
+9. Once bound, you can attach your device to WSL by running `usbipd attach --wsl -b <busid>` 
+on powershell/cmd (When attaching a device for the first time, it has to be done with 
+admin previliges).
+
+12. To check if the attach worked, run `lsusb` on WSL. If the whole process worked, the 
+device should be listed and JLink should be able to find it.
+
+13. The kernel can now be flashed with `make install` and other tockloader commands should work.
+
+
+>Note: 
+> - Make sure your firewall is not blocking port 3240 as USBIP uses that port to interface 
+> windows and WSL. (Windows defender is usually the culprit if you don't have a third party 
+> firewall).
+
+> - Add an inbound rule to Windows defender/ your third party firewall allowing USBIP to use 
+> port 3240 if you see a port blocked error.
+
 > #### One-Time Fixups
 >
 > - On Linux, you might need to give your user access to the serial port used by

--- a/src/getting_started.md
+++ b/src/getting_started.md
@@ -195,68 +195,69 @@ The board should appear as a regular serial device (e.g.
 `/dev/tty.usbserial-c098e5130006` on my Mac or `/dev/ttyUSB0` on my Linux box).
 This may require some setup, see the "one-time fixups" box.
 
-
 ### On Windows Subsystem for Linux (WSL)
 
 Programming JLink devices with Tock in WSL:
 
-Trying to program an nRF52840DK with WSL can be a little tricky because WSL2 
-abstracts away low level access for USB devices. WSL1 is unable to find JLink 
-devices even if you have JLink installed because of the USB abstraction. 
-To get around this, we use USBIP - a tool that connects the USB device over a 
-TCP tunnel. This guide might apply for any device programmed via JLink. 
+Trying to program an nRF52840DK with WSL can be a little tricky because WSL2
+abstracts away low level access for USB devices. WSL1 is unable to find JLink
+devices even if you have JLink installed because of the USB abstraction. To get
+around this, we use USBIP - a tool that connects the USB device over a TCP
+tunnel. This guide might apply for any device programmed via JLink.
 
 Steps to connect to nRF52840DK with WSL:
 
-1. Get Ubuntu 22.04 from microsoft store. Install it as a WSL distro with 
-`wsl --install -d Ubuntu-22.04` using Windows Powershell or Cmd prompt with 
-admin previliges. 
+1. Get Ubuntu 22.04 from microsoft store. Install it as a WSL distro with
+   `wsl --install -d Ubuntu-22.04` using Windows Powershell or Cmd prompt with
+   admin previliges.
 
-2. Once Ubuntu 22.04 is installed, the Ubuntu 20.04 distro that ships as 
-default with WSL must be uninstalled. Set the 22.04 distro as the WSL 
-default by with the `wsl --setdefault Ubuntu-22.04` command. 
+2. Once Ubuntu 22.04 is installed, the Ubuntu 20.04 distro that ships as default
+   with WSL must be uninstalled. Set the 22.04 distro as the WSL default by with
+   the `wsl --setdefault Ubuntu-22.04` command.
 
-3. Install JLink's linux package from their website on your WSL linux distro. 
-You may need to modify jlink rules to allow JLink to access the nRF52840DK. 
-This can be done with `sudo nano /etc/udev/rules.d/99-jlink.rules` and 
-adding `SUBSYSTEM=="tty", ATTRS{idVendor}=="1051", MODE="0666", GROUP="dialout"` 
-to the file.
+3. Install JLink's linux package from their website on your WSL linux distro.
+   You may need to modify jlink rules to allow JLink to access the nRF52840DK.
+   This can be done with `sudo nano /etc/udev/rules.d/99-jlink.rules` and adding
+   `SUBSYSTEM=="tty", ATTRS{idVendor}=="1051", MODE="0666", GROUP="dialout"` to
+   the file.
 
-4. Next, the udev rules have to be reloaded and triggered with 
-`sudo udevadm control --reload-rules && udevadm trigger`. Doing this should 
-apply the new rules.
+4. Next, the udev rules have to be reloaded and triggered with
+   `sudo udevadm control --reload-rules && udevadm trigger`. Doing this should
+   apply the new rules.
 
-5. On the windows platform, make sure WSL is set to version 2. Check the WSL 
-version with `wsl -l -v`. If it is version 1, change it to WSL2 with 
-`wsl --set-version Ubuntu-22.04 2`. 
+5. On the windows platform, make sure WSL is set to version 2. Check the WSL
+   version with `wsl -l -v`. If it is version 1, change it to WSL2 with
+   `wsl --set-version Ubuntu-22.04 2`.
 
-6. Install USBIP from [here](https://github.com/dorssel/usbipd-win/releases/tag/v4.1.0). 
-Version 4.x onwards removes USBIP tooling requirement from the client side, so you don't 
-have to install anything on the linux subsystem. 
+6. Install USBIP from
+   [here](https://github.com/dorssel/usbipd-win/releases/tag/v4.1.0). Version
+   4.x onwards removes USBIP tooling requirement from the client side, so you
+   don't have to install anything on the linux subsystem.
 
-7. On windows, open powershell/cmd in admin mode and run `usbipd wsl list`. That should 
-give you the list of devices. Note the Bus ID of your J-Link device.
+7. On windows, open powershell/cmd in admin mode and run `usbipd wsl list`. That
+   should give you the list of devices. Note the Bus ID of your J-Link device.
 
-8. For the first time that you want to attach your device, you need to bind the bus between 
-the host OS and the WSL using `usbipd bind -b <bus-id>`.
+8. For the first time that you want to attach your device, you need to bind the
+   bus between the host OS and the WSL using `usbipd bind -b <bus-id>`.
 
-9. Once bound, you can attach your device to WSL by running `usbipd attach --wsl -b <busid>` 
-on powershell/cmd (When attaching a device for the first time, it has to be done with 
-admin previliges).
+9. Once bound, you can attach your device to WSL by running
+   `usbipd attach --wsl -b <busid>` on powershell/cmd (When attaching a device
+   for the first time, it has to be done with admin previliges).
 
-12. To check if the attach worked, run `lsusb` on WSL. If the whole process worked, the 
-device should be listed and JLink should be able to find it.
+10. To check if the attach worked, run `lsusb` on WSL. If the whole process
+    worked, the device should be listed and JLink should be able to find it.
 
-13. The kernel can now be flashed with `make install` and other tockloader commands should work.
+11. The kernel can now be flashed with `make install` and other tockloader
+    commands should work.
 
+> #### Note:
+>
+> - Make sure your firewall is not blocking port 3240 as USBIP uses that port to
+>   interface windows and WSL. (Windows defender is usually the culprit if you
+>   don't have a third party firewall).
 
->Note: 
-> - Make sure your firewall is not blocking port 3240 as USBIP uses that port to interface 
-> windows and WSL. (Windows defender is usually the culprit if you don't have a third party 
-> firewall).
-
-> - Add an inbound rule to Windows defender/ your third party firewall allowing USBIP to use 
-> port 3240 if you see a port blocked error.
+> - Add an inbound rule to Windows defender/ your third party firewall allowing
+>   USBIP to use port 3240 if you see a port blocked error.
 
 > #### One-Time Fixups
 >

--- a/src/getting_started.md
+++ b/src/getting_started.md
@@ -199,11 +199,14 @@ This may require some setup, see the "one-time fixups" box.
 
 Programming JLink devices with Tock in WSL:
 
-Trying to program an nRF52840DK with WSL can be a little tricky because WSL2
-abstracts away low level access for USB devices. WSL1 is unable to find JLink
-devices even if you have JLink installed because of the USB abstraction. To get
-around this, we use USBIP - a tool that connects the USB device over a TCP
-tunnel. This guide might apply for any device programmed via JLink.
+Trying to program an nRF52840DK with WSL can be a little tricky because WSL
+abstracts away low level access for USB devices. WSL1 does not offer access to
+physical hardware, just an environment to use linux on microsoft. WSL2 on the
+other hand is unable to find JLink devices even if you have JLink installed
+because of the USB abstraction. To get around this limitation, we use USBIP - a
+tool that connects the USB device over a TCP tunnel.
+
+This guide might apply for any device programmed via JLink.
 
 Steps to connect to nRF52840DK with WSL:
 
@@ -227,7 +230,7 @@ Steps to connect to nRF52840DK with WSL:
 
 5. On the windows platform, make sure WSL is set to version 2. Check the WSL
    version with `wsl -l -v`. If it is version 1, change it to WSL2 with
-   `wsl --set-version Ubuntu-22.04 2`.
+   `wsl --set-version Ubuntu-22.04 2` (USBIP works with WSL2).
 
 6. Install USBIP from
    [here](https://github.com/dorssel/usbipd-win/releases/tag/v4.1.0). Version
@@ -252,6 +255,8 @@ Steps to connect to nRF52840DK with WSL:
 
 > #### Note:
 >
+> - A machine with an x64 processor is required. (x86 and Arm64 are currently
+>   not supported with USBIP).
 > - Make sure your firewall is not blocking port 3240 as USBIP uses that port to
 >   interface windows and WSL. (Windows defender is usually the culprit if you
 >   don't have a third party firewall).


### PR DESCRIPTION
Existing documentation discusses how to setup for Linux or a virtual machine. However, in my attempts to get tock running with WSL, I had to do extra stuff not mentioned in the documentation. So I put together a guide on setting tock with WSL in the `getting-started.md` page, specifically under the `Getting the Hardware Connected and Setup` section.

These extra steps were required because WSL does not directly recognize USB devices attached to Windows, so we use a separate tool to create a TCP tunnel between Windows and WSL. 

Additionally, there was a typo (I think?) I noticed in `syscalls.md` that I fixed.