### PR TITLE
make: support `make fmt` and `make format`

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -53,6 +53,8 @@ all:	check_mdbook check_mdbook_linkcheck check_mdbook_webinclude check_mdbook_pa
 pretty:	check_prettier
 	$(PRETTIER) --write --prose-wrap always '**/*.md'
 
+fmt format: pretty
+
 install_mdbook:
 ifndef CI
 	cargo install mdbook --version $(MDBOOK_VERSION)


### PR DESCRIPTION
So I don't have to remember different commands for different repos.