### PR TITLE
Root of Trust course updates

### DIFF
--- a/src/course/root-of-trust/encryption-service.md
+++ b/src/course/root-of-trust/encryption-service.md
@@ -1,14 +1,16 @@
 # Encryption Service Userspace Application
 
-As a reminder, this guide guides you through creating an encryption service that
-we'll use in later parts to demonstrate Tock's strengths as a hardware root of
-trust OS.
+This submodule guides you through creating and using an encryption service.
+Providing an encryption service is a common feature of a HWRoT.
 
-We have already configured our kernel as needed to provide access to the OLED
-screen and the _encryption oracle_ driver from the
-[HOTP demo](../usb-security-key/key-overview.md). This driver has a built-in AES
-key that we can use to encrypt messages without our userspace application ever
-making contact with the key itself.
+An encryption service can cryptographically encrypt and/or decrypt data on
+behalf of an application. Crucially, the service encapsulates the encryption
+key, preventing the application from ever having access to the key. This also
+prevents an attacker from being able to retrieve the key, enhancing the security
+of the encrypted data.
+
+Once we setup the encryption service, we will use it throughout this course to
+demonstrate Tock's strengths as a hardware root of trust OS.
 
 ## Background
 
@@ -77,7 +79,7 @@ In order to easily allow asynchronous driver interfaces, the Tock driver allows
 registering _upcalls_, callbacks which kernel drivers can invoke e.g. to signal
 to an app that a requested operation has completed.
 
-### Interprocess Communication in Tock
+### Inter-process Communication (IPC) in Tock
 
 Tock has an IPC driver in the kernel which allows userspace apps to advertise
 _IPC services_ with names such as `org.tockos.tutorial.led_service`.
@@ -89,12 +91,43 @@ some operation.
 
 ## Submodule Overview
 
+We will be developing two userspace applications. The first provides a user
+interface with the screen and buttons. The second is the encryption service
+application. An overview of the structure is here:
+
+```
+             ┌──────────────────┐       ┌────────────────────┐
+             │                  │       │                    │
+             │ Screen App       │  IPC  │ Encryption Service │
+             │                  │◄─────►├─App                │
+             │ UI + Logging     │       │                    │
+             │                  │       │                    │
+             └───┬───────┬──────┘       └──┬───────────┬─────┘
+Userspace        │       │                 │           │
+─────────────────┼───────┼─────────────────┼───────────┼──────
+Tock          ┌──▼───┐┌──▼────┐      ┌─────▼────────┐┌─▼─────┐
+Kernel        │Screen││Buttons│      │AES Encryption││Console│
+              └──────┘└───────┘      │Oracle        │└───────┘
+                                     └──────────────┘
+```
+
+The two applications will communicate using IPC. We will focus on creating the
+encryption service app, and use the screen app to help interact with the user.
+
+Each application uses capsules provided by the kernel. The capsules have already
+been created and are already included with the kernel we installed. Consistent
+with our goal for an HWRoT encryption service, the AES Encryption Oracle has a
+built-in AES key that we can use to encrypt messages without our userspace
+application ever making contact with the key itself.
+
+### Milestones
+
 We have three small milestones in this section, all of which build upon supplied
 starter code.
 
-1. Milestone one adds support for interacing with a dispatch/logging service, to
-   illustrate how various root of trust services might be dispatched in practice
-   while maintaining separation.
+1. Milestone one adds support for interfacing with a dispatch/logging service,
+   to illustrate how various root of trust services might be dispatched in
+   practice while maintaining separation.
 2. Milestone two adds support for sending/receiving data and serializing
    plaintext, introducing how libtock-c APIs work.
 3. Milestone three adds actual encryption support using the encryption oracle
@@ -106,6 +139,12 @@ Before starting, check the following:
 
 1. Make sure you have compiled and installed the Tock kernel with the screen and
    encryption oracle drivers on to your board.
+
+   ```
+   cd tock/boards/tutorials/nrf52840dk-root-of-trust-tutorial
+   make install
+   ```
+
 2. Make sure you have no testing apps installed. To remove all apps:
 
    ```
@@ -172,7 +211,7 @@ functionalities into different apps is helpful from a security perspective.
 We'll discuss this more in the next part of the tutorial.
 
 First, let's modify our scaffold in `encryption_service_starter/main.c` to
-respond to the main screen app's dispatch signal using Tock's interprocess
+respond to the main screen app's dispatch signal using Tock's inter-process
 communication (IPC) driver. Rename the directory in your local copy from
 `encryption_service_starter/` to `encryption_service/`. Completed code is
 available in `encryption_service_milestone_one/` if you run into issues.
@@ -386,9 +425,15 @@ type messages into the UART console when prompted to encrypt them.
 > messages sent over the UART console, logging the status of the encryption
 > capsule to the screen as it runs.
 
-Congratulations! Feel free to move on to the next section, where we'll begin to
-attack our implementation and show how Tock allows for defense-in-depth measures
+## Submodule Complete
+
+Congratulations! Feel free to move on to the
+[next section](userspace-attack.md), where we'll begin to attack our
+implementation and show how Tock allows for defense-in-depth measures
 appropriate for a root of trust operating system.
+
+If you have additional time or are looking to deepen your knowledge of Tock,
+continue to challenge section below.
 
 ## Challenge: Authenticating the Results
 

--- a/src/course/root-of-trust/overview.md
+++ b/src/course/root-of-trust/overview.md
@@ -6,12 +6,12 @@ placing emphasis on why Tock is well-suited for this role.
 
 ## Background
 
-A hardware root of trust (HWRoT) is a security-hardened device intended to
-provide the foundation of trust for the system they're integrated into. Systems
-such as mobile phones, servers, and industrial control systems run code and
-access data that needs to be trusted, and if compromised, could have severe
-negative impacts. HWRoTs serve to ensure the trustworthiness of the code and
-data their system uses to prevent these outcomes.
+A hardware root of trust (HWRoT) is a security-hardened device that provides the
+foundation of trust for another computing system. Systems such as mobile phones,
+servers, and industrial control systems run code and access data that needs to
+be trusted, and if compromised, could have severe negative impacts. HWRoTs serve
+to ensure the trustworthiness of the code and data their system uses to prevent
+these outcomes.
 
 HWRoTs can come in two flavors: discrete and integrated.
 
@@ -69,8 +69,8 @@ kinds of operations, including:
 
 - **Hardware attestation**: Often with internet-connected devices, it's
   important for a server to be able to verify that it's connected to a valid,
-  uncompromised device before transfering data back-and-forth. During boot, each
-  boot stage of a device with a HWRoT can generate and sign certificates
+  uncompromised device before transferring data back-and-forth. During boot,
+  each boot stage of a device with a HWRoT can generate and sign certificates
   attesting to the hash of the next boot stage's value. Each of these
   certificates establishes a _conditional trust_, demonstrating that a given
   stage is uncompromised, provided that all previous stages are also
@@ -93,14 +93,9 @@ For accessibility, we will use a standard microcontroller in this demo rather
 than an actual hardware root of trust; that said, the principles in this demo
 apply readily to any HWRoT.
 
-To fully follow this guide you will need a hardware board that supports a
-peripheral USB port (i.e. where the microcontroller has USB hardware support).
-In the future, this tutorial may be extended to support other boards, but for
-now only the nrf52840dk is supported.
-
-Compatible boards:
-
-- nRF52840dk
+This guide was designed for the nRF52840dk with an attached screen. However,
+other hardware will work but will need some additional configuration to match
+the directions presented here.
 
 ## Goal
 

--- a/src/course/root-of-trust/userspace-attack.md
+++ b/src/course/root-of-trust/userspace-attack.md
@@ -46,15 +46,10 @@ definition we've been using for our kernel this whole time.
 2. Milestone two customizes Tock's response to this attack at the board
    definition level.
 
-## Setup
-
-No additional setup is needed beyond the previous section.
-
 ## Starter Code
 
-The code in `libtock-c/examples/tutorials/root_of_trust/` for `screen/` remains
-the same, and starter code for the userspace attack application is in the
-`suspicious_service/` subdirectory.
+The starter code for the userspace attack application is in the
+`suspicious_service_starter/` subdirectory.
 
 To launch this 'suspicious' service which we'll use to dump userspace memory,
 simply navigate as per the previous submodule to the `Suspicious service` in the
@@ -66,12 +61,48 @@ To start, we first need to set up our attack application to attempt to dump
 memory from SRAM. If you get stuck, an implementation of this milestone is
 available at `suspicious_service_milestone_one/`.
 
-1. If you haven't yet, install the `suspicious_service` as previous using
-   `make install`
+1. In `libtock-c/examples/tutorials/root_of_trust/`, rename the directory
+   `suspicious_service_starter/` to just `suspicious_service/`.
 
-2. Next, obtain the start addresses of our attack service and the encryption
-   service we installed previously. To do this, we'll rebuild the kernel and add
-   an additional feature. Under our board definition in
+2. Inside `suspicious_service/main.c`, we'll want to start by adding everything
+   we needed from the previous step for interacting with the main screen
+   application. Copy over `wait_for_start()`, `setup_logging()`, and
+   `log_to_screen()` along with the IPC callbacks and global variables they rely
+   upon from the previous submodule to `suspicious_serivce/main.c`.
+
+3. Now we will dump the contents of the suspicious service's memory. In
+   `suspicious_service/main.c`, add a function `dump_memory()` that takes in a
+   `uint32_t *start` word pointer, a `uint32_t *end` word pointer, and a label
+   string, and loops over each address from start to end while printing out over
+   UART e.g. `[<LABEL>] <address>: <value>` to show the value at each memory
+   address.
+
+4. In main, call `dump_memory()` to dump the first 16KiB (`0x1000` words of
+   memory) of the `suspicious` SRAM dumping service you're modifying right now.
+
+   To get the address that our SRAM dumping application's memory starts at, Tock
+   supplies a
+   [`Memop`](https://book.tockos.org/trd/trd104-syscalls.html#46-memop-class-id-5)
+   class of syscalls we can use, which are nicely wrapped in utility functions
+   such as `tock_app_memory_begins_at()` in libtock-c.
+
+   If desired, use `log_to_screen()` to log when the memory dump starts/stops.
+   You should (when selecting the `Suspicious service` in the on-device menu)
+   successfully be able to retrieve the bytes of code of the running SRAM
+   dumping service.
+
+> **Checkpoint:** Your suspicious service application should be able to dump its
+> own memory contents.
+
+Now that we've established an app can dump its own memory, can it also dump the
+memory from _a different application_? Intuitively, processes shouldn't be able
+to read memory from other apps. However, embedded systems often do not provide
+the same isolation that we expect on servers, desktops, and phones. Let's try it
+to see what happens.
+
+1. We first want to obtain the addresses in memory the kernel allocated for the
+   encryption service we installed previously. To do this, we'll rebuild the
+   kernel and add an additional feature. Under our board definition in
    `tock/boards/tutorials nrf52840dk-root-of-trust-tutorial/`, you'll want to
    make the following change so that the process load debugging is enabled for
    the kernel:
@@ -89,8 +120,8 @@ available at `suspicious_service_milestone_one/`.
     screen_sh1106 = []
    ```
 
-3. After making this change, run (in the same directory) `make install` so that
-   the new kernel is uploaded. From there, press the `RESET` button on the
+2. After making this change, run (in the same directory) `make install` so that
+   the new kernel is installed. From there, press the `RESET` button on the
    board, and look at your `tockloader listen` console; it should show something
    like
 
@@ -109,37 +140,7 @@ available at `suspicious_service_milestone_one/`.
    starting with `Loading:`, we can clearly see that the SRAM range for the
    encryption service is `0x2000A000-0x2000BFFF`.
 
-4. Now that we know where the applications SRAM ranges are, we can attempt to
-   dump them. In `libtock-c/examples/tutorials/root_of_trust/`, rename the
-   directory `suspicious_service_starter/` to just `suspicious_service/`.
-
-5. Inside `suspicious_service/main.c`, we'll want to start by adding everything
-   we needed from the previous step for interacting with the main screen
-   application. Copy over `wait_for_start()`, `setup_logging()`, and
-   `log_to_screen()` along with the IPC callbacks and global variables they rely
-   upon from the previous submodule to `suspicious_serivce/main.c`.
-
-6. Now, in `suspicious_service/main.c`, add a function `dump_memory()` that
-   takes in a `uint32_t *start` word pointer, a `uint32_t *end` word pointer,
-   and a label string, and loops over each address from start to end while
-   printing out over UART e.g. `[<LABEL>] <address>: <value>` to show the value
-   at each memory address.
-
-7. In main, call `dump_memory()` to dump the first 16KiB (`0x1000` words of
-   memory) of the `suspicious` SRAM dumping service you're modifying right now.
-
-   To get the address that our SRAM dumping applications's memory starts at,
-   Tock supplies a
-   [`Memop`](https://book.tockos.org/trd/trd104-syscalls.html#46-memop-class-id-5)
-   class of syscalls we can use, which are nicely wrapped in utility functions
-   such as `tock_app_memory_begins_at()` in libtock-c.
-
-   If desired, use `log_to_screen()` to log when the memory dump starts/stops.
-   You should (when selecting the `Suspicious service` in the on-device menu)
-   successfully be able to retrieve the bytes of code of the running SRAM
-   dumping service.
-
-8. After that, try adding another `dump_memory()` call to dump the first
+3. After that, try adding another `dump_memory()` call to dump the first
    `0x1000` words of the encryption application. Because applications should
    never need to access each other's memory, you'll need to get this address
    from the debug output you collected in step 3. Once you've done this, your
@@ -235,6 +236,9 @@ would result in a hard fault, as we just saw. As such, even when the kernel is
 configured to accept arbitrary applications, runtime application isolation can
 be enforced.
 
+> **Checkpoint:** Your suspicious service application was blocked from reading
+> the memory of a different application!
+
 ## Milestone Two: Modifying our Kernel's Fault Policy
 
 When a system faults, it can be very useful to dump as much information as
@@ -321,7 +325,7 @@ Process has been stopped. Review logs.
 Out of the box, Tock was able to provide runtime application isolation between
 our encryption service and a malicious SRAM dumping application, and in just a
 few lines of code, we were able to customize our kernel's response to
-application faults to match our production HWRoT use caes.
+application faults to match our production HWRoT use case.
 
-In the next submodule, we'll explore one aspect of Tock's compile-time
-kernel-level isolation guarantees: _capabilities_.
+In the [next submodule](kernel-attack.md), we'll explore one aspect of Tock's
+compile-time kernel-level isolation guarantees: _capabilities_.


### PR DESCRIPTION
I went through the RoT tutorial and made some updates. High level: added more intro/overview to give a sense of what the goal of each submodule is, and re-ordered how the userspace attack steps are organized. Also a handful of minor fixes.