### PR TITLE
Fix out-of-sync text and code in syscall implementation guide

### DIFF
--- a/src/development/syscall.md
+++ b/src/development/syscall.md
@@ -233,7 +233,7 @@ The steps from the overview are elaborated on here.
    `allow_readonly` calls.
 
    By Tock convention, every syscall interface must at least support the command
-   call with `which == 0`. This allows applications to check if the syscall
+   call with `command_num == 0`. This allows applications to check if the syscall
    interface is supported on the current platform. The command must return a
    `CommandReturn::success()`. If the command is not present, then the kernel
    automatically has it return a failure with an error code of
@@ -243,7 +243,7 @@ The steps from the overview are elaborated on here.
    impl SyscallDriver for WS00123 {
        fn command(
            &self,
-           which: usize,
+           command_num: usize,
            r2: usize,
    		r3: usize,
    		caller_id: AppId) -> CommandReturn {
@@ -290,7 +290,7 @@ The steps from the overview are elaborated on here.
    	///        height to set as the the threshold for detection.
        fn command(
            &self,
-           which: usize,
+           command_num: usize,
            r2: usize,
    		r3: usize,
    		caller_id: AppId) -> CommandReturn {

--- a/src/development/syscall.md
+++ b/src/development/syscall.md
@@ -197,20 +197,20 @@ The steps from the overview are elaborated on here.
    	fn allow_readwrite(
    	    &self,
    	    appid: AppId,
-   	    which, usize,
+   	    command_num, usize,
    	    slice: ReadWriteAppSlice,
    	) -> Result<ReadWriteAppSlice, (ReadWriteAppSlice, ErrorCode)> { }
 
        fn allow_readonly(
            &self,
            app: AppId,
-           which: usize,
+           command_num: usize,
            slice: ReadOnlyAppSlice,
        ) -> Result<ReadOnlyAppSlice, (ReadOnlyAppSlice, ErrorCode)> { }
 
        fn command(
            &self,
-   	    which: usize,
+   	    command_num: usize,
    		r2: usize,
    		r3: usize,
    		caller_id: AppId) -> CommandReturn { }


### PR DESCRIPTION
In the syscall implementation guide, the code example uses both `which` and `command_num` while the text uses `which`. This PR fixes this mismatch.